### PR TITLE
Hooks into ActiveJob::ConfiguredJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ MyJob.perform_later
 # writes "Executed MyJob for unknown" to the rails log
 
 # with a user
-MyJob.perform_later job_user: User.find_by(email: 'mark@markrebec.com')
+MyJob.set(job_user: User.find_by(email: 'mark@markrebec.com')).perform_later
 # writes "Executed MyJob for mark@markrebec.com" to the rails log
 
 # if you're in a controller or some other context where you already have a current_user
 # you'll probably just want to pass that through.
-MyJob.perform_later job_user: current_user
+MyJob.set(job_user: current_user).perform_later
 ```
 
 ## Contributing

--- a/activejob-users.gemspec
+++ b/activejob-users.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files       = Dir["lib/**/*"]
   s.test_files  = Dir["spec/**/*"]
 
-  s.add_dependency "activejob"
+  s.add_dependency "rails"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/lib/active_job/arguments_ext.rb
+++ b/lib/active_job/arguments_ext.rb
@@ -1,0 +1,13 @@
+module ActiveJob
+  module ArgumentsExt
+    def serialize_variable(argument = nil)
+      serialize_argument(argument)
+    end
+
+    def deserialize_variable(argument = nil)
+      deserialize_argument(argument)
+    end
+  end
+end
+
+ActiveJob::Arguments.send(:extend, ActiveJob::ArgumentsExt)

--- a/lib/active_job/users.rb
+++ b/lib/active_job/users.rb
@@ -6,11 +6,11 @@ module ActiveJob
 
     included do
       def serialize
-        super.merge({ 'job_user' => job_user.try(:to_global_id) })
+        super.merge({ 'job_user' => ActiveJob::Arguments.serialize_variable(job_user) })
       end
 
       def deserialize(job_data)
-        self.job_user = GlobalID::Locator.locate(job_data['job_user'])
+        self.job_user = ActiveJob::Arguments.deserialize_variable(job_data['job_user'])
         super(job_data)
       end
 

--- a/lib/active_job/users.rb
+++ b/lib/active_job/users.rb
@@ -6,11 +6,11 @@ module ActiveJob
 
     included do
       def serialize
-        super.merge({ 'job_user' => job_user })
+        super.merge({ 'job_user' => job_user.try(:to_global_id) })
       end
 
       def deserialize(job_data)
-        self.job_user = job_data["job_user"]
+        self.job_user = GlobalID::Locator.locate(job_data['job_user'])
         super(job_data)
       end
 

--- a/lib/active_job/users.rb
+++ b/lib/active_job/users.rb
@@ -6,7 +6,7 @@ module ActiveJob
 
     included do
       def serialize
-        super.merge({ 'job_user': job_user })
+        super.merge({ 'job_user' => job_user })
       end
 
       def deserialize(job_data)

--- a/lib/active_job/users/version.rb
+++ b/lib/active_job/users/version.rb
@@ -1,5 +1,5 @@
 module ActiveJob
   module Users
-    VERSION = '0.0.3'
+    VERSION = '0.0.4'
   end
 end

--- a/lib/activejob-users.rb
+++ b/lib/activejob-users.rb
@@ -1,2 +1,5 @@
+require 'active_job'
+require 'active_job/base'
+require 'active_job/arguments_ext'
 require 'active_job/users'
 require 'active_job/users/version'

--- a/spec/active_job/users_spec.rb
+++ b/spec/active_job/users_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ActiveJob::Users do
 
     it 'serialize the job_user' do
       subject.job_user = user
-      expect(subject.serialize["job_user"]).to eq(user)
+      expect(subject.serialize["job_user"]['email']).to eq(user[:email])
     end
 
     it 'deserialize the job_user' do

--- a/spec/active_job/users_spec.rb
+++ b/spec/active_job/users_spec.rb
@@ -7,39 +7,30 @@ RSpec.describe ActiveJob::Users do
     let(:user) { {email: 'mark@markrebec.com'} }
 
     it 'extracts the job_user keyword argument' do
-      subject.arguments << {job_user: user}
-      subject.extract_job_user!
-
+      subject.job_user = user
       expect(subject.job_user).to eq(user)
     end
 
     it 'passes other keyword arguments through' do
-      subject.arguments << {job_user: user, foo: 'bar'}
-      subject.extract_job_user!
-
+      subject.job_user = user
+      subject.arguments << {foo: 'bar'}
       expect(subject.arguments.last).to eq({foo: 'bar'})
     end
   end
 
   context 'when a job_user argument is not passed to the job' do
     it 'sets the job_user to nil' do
-      subject.extract_job_user!
-
       expect(subject.job_user).to eq(nil)
     end
 
     it 'passes all keyword arguments through' do
       subject.arguments << {foo: 'bar'}
-      subject.extract_job_user!
-
       expect(subject.arguments.last).to eq({foo: 'bar'})
     end
   end
 
-  describe 'before_perform' do
-    it 'calls extract_job_user!' do
-      expect_any_instance_of(TestJob).to receive(:extract_job_user!)
-      TestJob.perform_now
-    end
+  it 'respond_to job_user' do
+    expect(subject).to respond_to(:job_user)
+    TestJob.perform_now
   end
 end

--- a/spec/active_job/users_spec.rb
+++ b/spec/active_job/users_spec.rb
@@ -16,9 +16,30 @@ RSpec.describe ActiveJob::Users do
       subject.arguments << {foo: 'bar'}
       expect(subject.arguments.last).to eq({foo: 'bar'})
     end
+
+    it 'serialize the job_user' do
+      subject.job_user = user
+      expect(subject.serialize["job_user"]).to eq(user)
+    end
+
+    it 'deserialize the job_user' do
+      subject.job_user = user
+      job = TestJob.deserialize(subject.serialize)
+      expect(job.job_user).to eq(user)
+    end
+
+    it 'passes job_user in enqueue' do
+      subject.enqueue(job_user: user)
+      expect(subject.job_user).to eq(user)
+    end
+
+    it 'passes job_user in set' do
+      expect_any_instance_of(TestJob).to receive(:job_user)
+      TestJob.set(job_user: user).perform_later
+    end
   end
 
-  context 'when a job_user argument is not passed to the job' do
+  context 'when a job_user is not passed to the job' do
     it 'sets the job_user to nil' do
       expect(subject.job_user).to eq(nil)
     end
@@ -27,10 +48,28 @@ RSpec.describe ActiveJob::Users do
       subject.arguments << {foo: 'bar'}
       expect(subject.arguments.last).to eq({foo: 'bar'})
     end
+
+    it 'serialize the job_user' do
+      expect(subject.serialize["job_user"]).to eq(nil)
+    end
+
+    it 'deserialize the job_user' do
+      job = TestJob.deserialize(subject.serialize)
+      expect(job.job_user).to eq(nil)
+    end
+
+    it 'passes job_user in enqueue' do
+      subject.enqueue(job_user: nil)
+      expect(subject.job_user).to eq(nil)
+    end
+
+    it 'passes job_user in set' do
+      expect_any_instance_of(TestJob).to receive(:job_user)
+      TestJob.perform_later
+    end
   end
 
   it 'respond_to job_user' do
     expect(subject).to respond_to(:job_user)
-    TestJob.perform_now
   end
 end


### PR DESCRIPTION
The following hooks into ActiveJob::ConfiguredJob to set new ActiveJob::Base property called `job_user`. This allows us to set a user without needing to pass or specify options to the `perform` method.